### PR TITLE
/api endpoints

### DIFF
--- a/server.js
+++ b/server.js
@@ -662,16 +662,19 @@ function most_forked(req, res, next) {
 }
 
 app.get('/api',api_endpoints)
+var api_routes;
 function api_endpoints(req, res, next)	{
   res.header("Access-Control-Allow-Origin","*");
-  var api_routes = {};
-  for (rtype in app.routes) { // get, post, put, delete
-      api_routes[rtype] = [];
-      for (r in app.routes[rtype]) {
-        if (app.routes[rtype][r].path.substring(0,4) === "/api") {
-          api_routes[rtype].push(app.routes[rtype][r])
+  if (!api_routes) {
+	api_routes = {};
+    for (rtype in app.routes) { // get, post, put, delete
+        api_routes[rtype] = [];
+        for (r in app.routes[rtype]) {
+          if (app.routes[rtype][r].path.substring(0,4) === "/api") {
+            api_routes[rtype].push(app.routes[rtype][r])
+          }
         }
-      }
+    }
   }
   res.send(api_routes);
 }


### PR DESCRIPTION
Something like this could allow someone to dynamically request the API endpoints available, rather than having to look up documentation.  This pulls the information from express' app.routes, and assumes that any URL with /api at the start is an api endpoint.  This code will automatically update /api for any routes added later (get,post,put,delete).  It's a little dirty that this is generated for every request to /api, but I'm not sure how we might want to cache this data.
