### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ tributary.render
 
 
 
-###Contexts
+### Contexts
 
 I'm using latest CodeMirror from git (updating every-so often)  
 I have customized the JSHINT options in addons/lint/javascript-lint.js to be:

--- a/static/README.md
+++ b/static/README.md
@@ -1,31 +1,31 @@
 ## Directory Structure
 
-#tributary.js, tributary.min.js
+# tributary.js, tributary.min.js
     This is the meat of the code for tributary and all the views. This provides the Backbone model which drives the live code functionality.
 
 
-#templates
+# templates
 Handlebars templates vor various ui components
 
-#lib
+# lib
 The many js libraries tributary includes
 
-#css
+# css
 The stylesheets
 
-#img
+# img
 Static image assets
 
-#java
+# java
 experimental inclusion for doing MIDI in the browser
 
-#svgs
+# svgs
 experimental area for some svgs I was playing with.
 
-#gallery.json
+# gallery.json
 old way of generating a dynamic gallery, may revist
 
-#views (depracated)
+# views (depracated)
 The views are the different endpoints of tributary which give us a different view of the code being developed. Each view extends the base tributary model and adds it's own assumptions.
 The views have been ported to contexts and controls in the main tributary/src folder
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
